### PR TITLE
Fix filename to delete

### DIFF
--- a/audio.bash
+++ b/audio.bash
@@ -59,4 +59,4 @@ rm $OUTDIR/jvs098/parallel100/wav24kHz16bit/jvs098_VOICEACTRESS100_099.wav
 
 # missing lab
 rm $OUTDIR/jvs010/nonpara30/wav24kHz16bit/jvs010_LOANWORD128_089.wav
-rm $OUTDIR/jvs058/parallel100/wav24kHz16bit/jvs098_VOICEACTRESS100_022.wav
+rm $OUTDIR/jvs058/parallel100/wav24kHz16bit/jvs058_VOICEACTRESS100_022.wav


### PR DESCRIPTION
This will fix the following error on `audio.bash` execution:

```
rm: cannot remove '/home/user/data/jvs_r9y9_ver1/jvs058/parallel100/wav24kHz16bit/jvs098_VOICEACTRESS100_022.wav': No such file or directory
```

`jvs098_VOICEACTRESS100_022` has the corresponding labels:

```
$ find . | grep jvs098_VOICEACTRESS100_022
./jvs098/parallel100/lab/ful/jvs098_VOICEACTRESS100_022.lab
./jvs098/parallel100/lab/mon/jvs098_VOICEACTRESS100_022.lab
./jvs098/parallel100/wav24kHz16bit/jvs098_VOICEACTRESS100_022.wav
```

and `jvs058_VOICEACTRESS100_022` does not:

```
$ find . | grep jvs058_VOICEACTRESS100_022
./jvs058/parallel100/wav24kHz16bit/jvs058_VOICEACTRESS100_022.wav
```